### PR TITLE
Feature toggle added to allow list subscribers to email a list (discussion list type behaviour)

### DIFF
--- a/plugins/submitByMailPlugin/configure_a_list.php
+++ b/plugins/submitByMailPlugin/configure_a_list.php
@@ -82,6 +82,7 @@ if (isset($_POST['update'])) { // 'Save button clicked
 		}
 		$dispose = $_POST['mdisposal'] == 'Queue'? 1 : 0;
 		$cfm = $_POST['confirm'] == 'Yes'? 1 : 0;
+		$subscansend = $_POST['subscansend'] == 'Yes'? 1 : 0;
 		$nonly = $_POST['nameonly'];
 		if ((isset($_POST['template'])) &&  (is_numeric($_POST['template'])) && ($_POST['template'] > 0))
 			$tmplt = $_POST['template'];
@@ -90,9 +91,9 @@ if (isset($_POST['update'])) { // 'Save button clicked
 		$query = sprintf("select submissionadr from %s where id=%d",$sbm->tables['list'], $listid);
 		if (!Sql_Num_Rows(Sql_Query($query))) {	// Sql_Query is supposed to return false when a query fails
 												// It does not seem to do that here.
-			$query = sprintf("insert into %s values (%d, '%s', '%s', '%s', %d, %d, %d, %d, '%s', %d)", $sbm->tables['list'], $listid, $server, $subadr, $pass, $method, $cfm, $dispose, $tmplt, $ftr, $nonly);
+			$query = sprintf("insert into %s values (%d, '%s', '%s', '%s', %d, %d, %d, %d, '%s', %d, %d)", $sbm->tables['list'], $listid, $server, $subadr, $pass, $method, $cfm, $dispose, $tmplt, $ftr, $nonly, $subscansend);
 		} else {
-			$query = sprintf("update %s set pop3server='%s', submissionadr='%s', password='%s', pipe_submission=%d, confirm=%d, queue=%d, template=%d, footer='%s', nameonly=%d where id=%d", $sbm->tables['list'], $server, $subadr, $pass, $method, $cfm, $dispose, $tmplt, $ftr, $nonly, $listid);
+			$query = sprintf("update %s set pop3server='%s', submissionadr='%s', password='%s', pipe_submission=%d, confirm=%d, queue=%d, template=%d, footer='%s', nameonly=%d, subscribers_can_send=%d where id=%d", $sbm->tables['list'], $server, $subadr, $pass, $method, $cfm, $dispose, $tmplt, $ftr, $nonly, $subscansend, $listid);
 		}
 		if (!Sql_Query($query)) {
 			$ln = listName($listid);

--- a/plugins/submitByMailPlugin/edit_list.php
+++ b/plugins/submitByMailPlugin/edit_list.php
@@ -60,8 +60,8 @@ foreach ($listArray as $val)
 	if ($val[1]) $adrsList[$val[1]] = $val[0];
 	
 // Set up defaults for form
-$eml = $user = $pass = $msyes = $pipe = $cfmno = $queue = '';
-$save = $pop = $cfmyes = $msno = $ckd = 'checked';
+$eml = $user = $pass = $msyes = $pipe = $cfmno = $queue = $subscansendyes = '';
+$save = $pop = $cfmyes = $msno = $ckd = $subscansendno ='checked';
 $tmplt = 0;
 $footer = getConfig('messagefooter');
 
@@ -99,6 +99,13 @@ if ($row = Sql_Fetch_Assoc_Query($query)) {
 	} else {
 		$save = $ckd;
 		$queue = '';
+	}
+	if ($row['subscribers_can_send']) {
+		$subscansendyes = $ckd;
+		$subscansendno = '';
+	} else {
+		$subscansendno = $ckd;
+		$subscansendyes = '';
 	}
 	$tmplt = $row['template'];
 	$footer = stripslashes($row['footer']); // Magic quotes apparently! :-(
@@ -151,7 +158,9 @@ style="width:125px !important; display:inline !important;" value="$pass" maxleng
 <label style="display:inline !important;">What to do with submitted message:</label>&nbsp;&nbsp;<input type="radio" name="mdisposal" 
 value="Save" $save /><label style="display:inline !important;">Save</label>&nbsp;&nbsp;&nbsp;&nbsp;<input type="radio" name="mdisposal" value="Queue" $queue /><label style="display:inline !important;">Queue</label>
 <br /><br /><label style="display:inline !important;">Confirm submission:</label>&nbsp;&nbsp;<input type="radio" name="confirm" value="Yes" $cfmyes /><label style="display:inline !important;">Yes</label>&nbsp;&nbsp;&nbsp;&nbsp;
-<input type="radio" name="confirm" value="No" $cfmno /><label style="display:inline !important;">No</label>$template_form $footer_form
+<input type="radio" name="confirm" value="No" $cfmno /><label style="display:inline !important;">No</label>
+<br /><br /><label style="display:inline !important;">List subscribers can send mail to list:</label>&nbsp;&nbsp;<input type="radio" name="subscansend" value="Yes" $subscansendyes /><label style="display:inline !important;">Yes</label>&nbsp;&nbsp;&nbsp;&nbsp;
+<input type="radio" name="subscansend" value="No" $subscansendno /><label style="display:inline !important;">No</label>$template_form $footer_form
 <input class="submit" type="submit" name="submitter" value="Save" />
 EOD;
 


### PR DESCRIPTION
I needed a way to allow any subscriber of a list email the rest of the list. This seems to work okay.

New option added to list table (uses default old behaviour if it's not there).
Option added to list edit screen.
Not sure if the new column would be automatically added to existing installations... if not, this SQL would do it:

```
ALTER TABLE `phplist`.`phplist_submitByMailPlugin_list` 
ADD COLUMN `subscribers_can_send` TINYINT(4) NULL DEFAULT '0' AFTER `nameonly`;
```